### PR TITLE
Add Pomodoro Buddy support page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.0.0",
       "dependencies": {
         "react": "^19.1.0",
-        "react-dom": "^19.1.0"
+        "react-dom": "^19.1.0",
+        "react-router-dom": "^7.13.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.29.0",
@@ -1936,6 +1937,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -2907,6 +2921,44 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.13.0.tgz",
+      "integrity": "sha512-PZgus8ETambRT17BUm/LL8lX3Of+oiLaPuVTRH3l1eLvSPpKO3AvhAEb5N7ihAFZQrYDqkvvWfFh9p0z9VsjLw==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.13.0.tgz",
+      "integrity": "sha512-5CO/l5Yahi2SKC6rGZ+HDEjpjkGaG/ncEP7eWFTvFxbHP8yeeI0PxTDjimtpXYlR3b3i9/WIL4VJttPrESIf2g==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.13.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -3007,6 +3059,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   },
   "dependencies": {
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "react-router-dom": "^7.13.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.29.0",

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,13 +1,20 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import { BrowserRouter, Routes, Route } from 'react-router-dom'
 import './index.css'
 import App from './App.tsx'
+import PomodoroBuddySupport from './pages/PomodoroBuddySupport.tsx'
 import { ThemeProvider } from './contexts/ThemeContext'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <ThemeProvider>
-      <App />
+      <BrowserRouter>
+        <Routes>
+          <Route path="/" element={<App />} />
+          <Route path="/pomodoro-buddy-support" element={<PomodoroBuddySupport />} />
+        </Routes>
+      </BrowserRouter>
     </ThemeProvider>
   </StrictMode>,
 )

--- a/src/pages/PomodoroBuddySupport.css
+++ b/src/pages/PomodoroBuddySupport.css
@@ -1,0 +1,210 @@
+.support-page {
+  width: 100vw;
+  min-height: 100vh;
+  background-color: var(--bg-secondary);
+  position: relative;
+}
+
+.support-container {
+  width: 680px;
+  margin: 0 auto;
+  padding: 60px 40px 80px 40px;
+  background-color: var(--bg-primary);
+  box-shadow: 0 0 50px var(--shadow-color);
+  position: relative;
+  z-index: 10;
+  min-height: 100vh;
+  transition: background-color 0.3s ease, box-shadow 0.3s ease;
+}
+
+.support-header {
+  margin-bottom: 48px;
+  padding-bottom: 32px;
+  border-bottom: 1px solid var(--border-color);
+  transition: border-color 0.3s ease;
+}
+
+.support-title {
+  font-size: 2.2rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  letter-spacing: -0.02em;
+  margin-bottom: 4px;
+  transition: color 0.3s ease;
+}
+
+.support-subtitle {
+  font-size: 1.1rem;
+  color: var(--text-secondary);
+  font-weight: 400;
+  transition: color 0.3s ease;
+}
+
+.support-content {
+  display: flex;
+  flex-direction: column;
+  gap: 48px;
+}
+
+.support-section {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.support-section-title {
+  font-size: 1.3rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  letter-spacing: -0.01em;
+  padding-bottom: 12px;
+  border-bottom: 1px solid var(--border-color);
+  transition: color 0.3s ease, border-color 0.3s ease;
+}
+
+.support-section h3 {
+  font-size: 1.05rem;
+  font-weight: 500;
+  color: var(--text-primary);
+  margin-top: 8px;
+  transition: color 0.3s ease;
+}
+
+.support-section p {
+  font-size: 0.95rem;
+  line-height: 1.7;
+  color: var(--text-secondary);
+  transition: color 0.3s ease;
+}
+
+.support-section ul {
+  list-style: none;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.support-section li {
+  font-size: 0.95rem;
+  line-height: 1.7;
+  color: var(--text-secondary);
+  padding-left: 20px;
+  position: relative;
+  transition: color 0.3s ease;
+}
+
+.support-section li::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 10px;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background-color: var(--text-muted);
+  transition: background-color 0.3s ease;
+}
+
+.support-section li strong {
+  color: var(--text-primary);
+  transition: color 0.3s ease;
+}
+
+.support-section strong {
+  color: var(--text-primary);
+  font-weight: 500;
+  transition: color 0.3s ease;
+}
+
+.faq-item,
+.troubleshoot-item {
+  padding: 20px 24px;
+  background-color: var(--link-bg);
+  border-radius: 8px;
+  border: 1px solid var(--border-secondary);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  transition: background-color 0.3s ease, border-color 0.3s ease;
+}
+
+.faq-item h3,
+.troubleshoot-item h3 {
+  margin-top: 0;
+}
+
+.support-contact {
+  text-align: center;
+  align-items: center;
+  padding: 32px;
+  background-color: var(--link-bg);
+  border-radius: 8px;
+  border: 1px solid var(--border-secondary);
+  transition: background-color 0.3s ease, border-color 0.3s ease;
+}
+
+.contact-link {
+  display: inline-block;
+  padding: 12px 24px;
+  background-color: var(--bg-primary);
+  color: var(--text-primary);
+  text-decoration: none;
+  border-radius: 8px;
+  font-size: 0.95rem;
+  font-weight: 500;
+  border: 1px solid var(--border-secondary);
+  transition: all 0.2s ease;
+}
+
+.contact-link:hover {
+  background-color: var(--link-hover-bg);
+  color: var(--link-hover-text);
+  border-color: var(--link-hover-bg);
+  transform: translateY(-1px);
+}
+
+.contact-note {
+  font-size: 0.9rem;
+  color: var(--text-muted);
+  margin-top: 4px;
+}
+
+@media (max-width: 768px) {
+  .support-container {
+    width: 100%;
+    max-width: 100%;
+    padding: 32px 20px 60px 20px;
+    box-shadow: none;
+  }
+
+  .support-header {
+    margin-bottom: 32px;
+    padding-bottom: 24px;
+  }
+
+  .support-title {
+    font-size: 1.8rem;
+  }
+
+  .support-subtitle {
+    font-size: 1rem;
+  }
+
+  .support-content {
+    gap: 36px;
+  }
+
+  .support-section-title {
+    font-size: 1.15rem;
+  }
+
+  .faq-item,
+  .troubleshoot-item {
+    padding: 16px 18px;
+  }
+
+  .support-contact {
+    padding: 24px 18px;
+  }
+}

--- a/src/pages/PomodoroBuddySupport.tsx
+++ b/src/pages/PomodoroBuddySupport.tsx
@@ -1,0 +1,200 @@
+import './PomodoroBuddySupport.css'
+import ThemeToggle from '../components/ThemeToggle'
+
+function PomodoroBuddySupport() {
+  return (
+    <div className="support-page">
+      <ThemeToggle />
+      <div className="support-container">
+        <header className="support-header">
+          <h1 className="support-title">Pomodoro Buddy</h1>
+          <p className="support-subtitle">Support & Help</p>
+        </header>
+
+        <main className="support-content">
+          <section className="support-section">
+            <h2 className="support-section-title">Getting Started</h2>
+            <p>
+              Pomodoro Buddy is a focus timer app that uses the Pomodoro
+              Technique to help you work in structured intervals. Open the app,
+              tap play, and start your first focus session.
+            </p>
+
+            <h3>Timer Modes</h3>
+            <ul>
+              <li>
+                <strong>Pomodoro Mode</strong> — Work sessions followed by short
+                breaks, with a long break after a set number of sessions. The
+                app handles the full cycle automatically.
+              </li>
+              <li>
+                <strong>Simple Mode</strong> — A single focus timer with no
+                automatic break cycling. Start and stop whenever you want.
+              </li>
+            </ul>
+            <p>
+              You can switch between modes in the <strong>Settings</strong> tab.
+            </p>
+
+            <h3>Customizing Durations</h3>
+            <p>In Settings, adjust:</p>
+            <ul>
+              <li>
+                <strong>Work duration</strong> — Length of each focus session
+                (1–60 minutes)
+              </li>
+              <li>
+                <strong>Short break</strong> — Length of short breaks between
+                sessions (1–30 minutes)
+              </li>
+              <li>
+                <strong>Long break</strong> — Length of the longer break after
+                completing a cycle (5–60 minutes)
+              </li>
+              <li>
+                <strong>Long break after</strong> — Number of work sessions
+                before a long break (2–8 sessions)
+              </li>
+            </ul>
+
+            <h3>Focus Mode</h3>
+            <p>
+              Tap the <strong>Focus Mode</strong> button on the timer screen to
+              enter an immersive fullscreen view. Tap anywhere to show or hide
+              the controls. Tap the palette icon to cycle through background
+              gradients.
+            </p>
+
+            <h3>Live Activities</h3>
+            <p>
+              When a timer is running, Pomodoro Buddy displays your progress on
+              the Lock Screen and in the Dynamic Island. This lets you track your
+              session without opening the app.
+            </p>
+
+            <h3>Home Screen Widget</h3>
+            <p>
+              Add the Pomodoro Buddy widget to your home screen to see your
+              daily focus progress at a glance. Long-press your home screen, tap{' '}
+              <strong>+</strong>, search for "Pomodoro Buddy", and add the
+              widget.
+            </p>
+
+            <h3>Statistics</h3>
+            <p>
+              The <strong>Stats</strong> tab shows:
+            </p>
+            <ul>
+              <li>Today's completed sessions and focus minutes</li>
+              <li>Daily goal progress</li>
+              <li>Current streak</li>
+              <li>Weekly session chart</li>
+              <li>Recent session history</li>
+            </ul>
+
+            <h3>Notifications</h3>
+            <p>
+              Pomodoro Buddy sends a notification when each session completes.
+              You can enable or disable notifications in Settings. When prompted,
+              allow notifications for the best experience.
+            </p>
+          </section>
+
+          <section className="support-section">
+            <h2 className="support-section-title">Frequently Asked Questions</h2>
+
+            <div className="faq-item">
+              <h3>Does the timer work in the background?</h3>
+              <p>
+                Yes. When you leave the app, the timer continues running. A
+                notification will alert you when the session completes, and the
+                Live Activity on your Lock Screen shows the remaining time.
+              </p>
+            </div>
+
+            <div className="faq-item">
+              <h3>Can I change the daily goal?</h3>
+              <p>
+                Yes. Go to <strong>Settings</strong> and adjust the{' '}
+                <strong>Daily Goal</strong> to any number between 1 and 20
+                sessions.
+              </p>
+            </div>
+
+            <div className="faq-item">
+              <h3>How do I reset my data?</h3>
+              <p>
+                In Settings, scroll to the bottom and tap{' '}
+                <strong>Clear All Data</strong>. This will delete all session
+                history and reset settings to defaults. This action cannot be
+                undone.
+              </p>
+            </div>
+
+            <div className="faq-item">
+              <h3>Does the app collect any data?</h3>
+              <p>
+                No. All data is stored locally on your device. Pomodoro Buddy
+                has no accounts, no analytics, and no network communication.
+                Your data stays on your device.
+              </p>
+            </div>
+
+            <div className="faq-item">
+              <h3>Does the app work without an internet connection?</h3>
+              <p>Yes. Pomodoro Buddy works entirely offline.</p>
+            </div>
+          </section>
+
+          <section className="support-section">
+            <h2 className="support-section-title">Troubleshooting</h2>
+
+            <div className="troubleshoot-item">
+              <h3>Timer not showing on Lock Screen</h3>
+              <p>
+                Make sure Live Activities are enabled for Pomodoro Buddy. Go to{' '}
+                <strong>
+                  iOS Settings &rarr; Pomodoro Buddy &rarr; Live Activities
+                </strong>{' '}
+                and ensure it is turned on.
+              </p>
+            </div>
+
+            <div className="troubleshoot-item">
+              <h3>Not receiving notifications</h3>
+              <p>
+                Go to{' '}
+                <strong>
+                  iOS Settings &rarr; Pomodoro Buddy &rarr; Notifications
+                </strong>{' '}
+                and make sure notifications are allowed. Also check that
+                notifications are enabled within the app under{' '}
+                <strong>Settings &rarr; Notifications</strong>.
+              </p>
+            </div>
+
+            <div className="troubleshoot-item">
+              <h3>Widget not updating</h3>
+              <p>
+                Try removing and re-adding the widget. Widgets update
+                periodically and may take a moment to reflect your latest
+                session data.
+              </p>
+            </div>
+          </section>
+
+          <section className="support-section support-contact">
+            <h2 className="support-section-title">Contact</h2>
+            <p>If you need help or have feedback, reach out at:</p>
+            <a href="mailto:support@example.com" className="contact-link">
+              support@example.com
+            </a>
+            <p className="contact-note">We'd love to hear from you.</p>
+          </section>
+        </main>
+      </div>
+    </div>
+  )
+}
+
+export default PomodoroBuddySupport

--- a/src/pages/PomodoroBuddySupport.tsx
+++ b/src/pages/PomodoroBuddySupport.tsx
@@ -186,8 +186,8 @@ function PomodoroBuddySupport() {
           <section className="support-section support-contact">
             <h2 className="support-section-title">Contact</h2>
             <p>If you need help or have feedback, reach out at:</p>
-            <a href="mailto:support@example.com" className="contact-link">
-              support@example.com
+            <a href="mailto:support@danialbeg.com" className="contact-link">
+              support@danialbeg.com
             </a>
             <p className="contact-note">We'd love to hear from you.</p>
           </section>


### PR DESCRIPTION
Summary

  - Adds a styled support/help page for Pomodoro Buddy at /pomodoro-buddy-support
  - Page is URL-only accessible with no navigation links from the main portfolio
  - Introduces react-router-dom for client-side routing
  - Matches existing portfolio theme system (light/dark mode) and is mobile responsive

 Test plan
  - Visit / and confirm the portfolio renders as before
  - Visit /pomodoro-buddy-support and confirm the support page renders correctly
  - Toggle light/dark theme on the support page
  - Verify no links to the support page exist on the main portfolio
  - Test mobile responsiveness on the support page